### PR TITLE
feat: add Apple TV style homepage skeleton

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Apple TV Style Homepage</title>
+  </head>
+  <body class="bg-black text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "apple-tv-homepage",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "framer-motion": "^10.16.4"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,21 @@
+import Navbar from './components/Navbar.jsx';
+import Hero from './components/Hero.jsx';
+import Features from './components/Features.jsx';
+import Testimonials from './components/Testimonials.jsx';
+import CTASection from './components/CTASection.jsx';
+import Footer from './components/Footer.jsx';
+
+export default function App() {
+  return (
+    <div className="font-sans">
+      <Navbar />
+      <main className="space-y-20">
+        <Hero />
+        <Features />
+        <Testimonials />
+        <CTASection />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/CTASection.jsx
+++ b/src/components/CTASection.jsx
@@ -1,0 +1,17 @@
+import { motion } from 'framer-motion';
+
+export default function CTASection() {
+  return (
+    <section className="py-20 bg-gradient-to-r from-purple-600 to-blue-600 text-center" id="cta">
+      <h2 className="text-4xl font-bold mb-4">Ready to Join?</h2>
+      <p className="mb-8 text-lg">Sign up today and start your journey.</p>
+      <motion.a
+        href="/signup"
+        className="inline-block px-8 py-4 bg-black text-white font-semibold rounded"
+        whileHover={{ scale: 1.05 }}
+      >
+        Join Now
+      </motion.a>
+    </section>
+  );
+}

--- a/src/components/Features.jsx
+++ b/src/components/Features.jsx
@@ -1,0 +1,54 @@
+import { motion, useViewportScroll, useTransform } from 'framer-motion';
+
+const features = [
+  {
+    image:
+      'https://images.unsplash.com/photo-1556761175-4b46a572b786?auto=format&fit=crop&w=600&q=80',
+    title: 'Feature One',
+    description: 'An amazing feature that does cool things.',
+  },
+  {
+    image:
+      'https://images.unsplash.com/photo-1506765515384-028b60a970df?auto=format&fit=crop&w=600&q=80',
+    title: 'Feature Two',
+    description: 'Another incredible feature for your users.',
+  },
+  {
+    image:
+      'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=600&q=80',
+    title: 'Feature Three',
+    description: 'This feature will blow your mind.',
+  },
+];
+
+export default function Features() {
+  const { scrollY } = useViewportScroll();
+  const y = useTransform(scrollY, [0, 300], [0, -50]);
+
+  return (
+    <section className="py-20" id="features">
+      <h2 className="text-3xl font-bold mb-8 text-center">Features</h2>
+      <div className="overflow-x-auto flex space-x-6 px-4 snap-x snap-mandatory">
+        {features.map((feature) => (
+          <motion.div
+            key={feature.title}
+            className="snap-center flex-shrink-0 w-72 bg-gray-800 rounded-lg p-4"
+            initial={{ opacity: 0, y: 50 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.5 }}
+            transition={{ duration: 0.5 }}
+          >
+            <motion.img
+              src={feature.image}
+              alt={feature.title}
+              className="mb-4 rounded"
+              style={{ y }}
+            />
+            <h3 className="text-xl font-semibold mb-2">{feature.title}</h3>
+            <p className="text-sm text-gray-300">{feature.description}</p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,11 @@
+export default function Footer() {
+  return (
+    <footer className="bg-black py-8 text-center text-gray-400">
+      <p>&copy; 2025 My Company. All rights reserved.</p>
+      <div className="mt-4 space-x-4">
+        <a href="https://twitter.com" aria-label="Twitter">Twitter</a>
+        <a href="https://github.com" aria-label="GitHub">GitHub</a>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,0 +1,29 @@
+import { motion, useViewportScroll, useTransform } from 'framer-motion';
+
+const bgImage =
+  'https://images.unsplash.com/photo-1522199710521-72d69614c702?auto=format&fit=crop&w=1400&q=80';
+
+export default function Hero() {
+  const { scrollY } = useViewportScroll();
+  const y = useTransform(scrollY, [0, 300], [0, 100]);
+
+  return (
+    <section className="relative h-screen flex items-center justify-center overflow-hidden">
+      <motion.div
+        style={{ y, backgroundImage: `url(${bgImage})` }}
+        className="absolute inset-0 bg-cover bg-center"
+      />
+      <div className="absolute inset-0 bg-black/50" />
+      <div className="relative z-10 text-center space-y-4 px-4">
+        <h1 className="text-5xl md:text-7xl font-bold">Cinematic Showcase</h1>
+        <p className="text-xl md:text-2xl">Experience projects in an Apple TV style.</p>
+        <a
+          href="/signup"
+          className="inline-block px-8 py-3 bg-white text-black font-semibold rounded hover:bg-gray-300 transition-colors"
+        >
+          Get Started
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,15 @@
+import { motion } from 'framer-motion';
+
+export default function Navbar() {
+  return (
+    <nav className="fixed top-0 left-0 w-full z-20 bg-black/50 backdrop-blur-sm">
+      <div className="max-w-6xl mx-auto flex items-center justify-between p-4">
+        <a href="/" className="text-xl font-bold">Logo</a>
+        <div className="space-x-4">
+          <a href="/features" className="hover:underline">Features</a>
+          <a href="/signup" className="hover:underline">Sign Up</a>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/Testimonials.jsx
+++ b/src/components/Testimonials.jsx
@@ -1,0 +1,30 @@
+import { motion } from 'framer-motion';
+
+const testimonials = [
+  { quote: 'This product changed my life.', name: 'Alice' },
+  { quote: 'A must-have for professionals.', name: 'Bob' },
+  { quote: 'Incredible experience and support.', name: 'Carol' },
+];
+
+export default function Testimonials() {
+  return (
+    <section className="py-20" id="testimonials">
+      <h2 className="text-3xl font-bold mb-8 text-center">What People Say</h2>
+      <div className="max-w-5xl mx-auto grid gap-8 md:grid-cols-3 px-4">
+        {testimonials.map((t, i) => (
+          <motion.div
+            key={t.name}
+            className="bg-gray-800 p-6 rounded"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: i * 0.2 }}
+          >
+            <p className="mb-4">“{t.quote}”</p>
+            <p className="font-semibold">— {t.name}</p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './styles/index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-black text-white antialiased;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold Vite + React project with TailwindCSS and Framer Motion
- implement cinematic Hero with parallax background and CTA
- add horizontally scrolling Features carousel with animated cards
- remove local PNG assets, using external imagery to keep repo lightweight

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f30d663c832fa987988af4e867cf