### PR TITLE
Modernize fonts and update navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Apple TV Style Homepage</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>
   <body class="bg-black text-white">
     <div id="root"></div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,10 +1,9 @@
 export default function Footer() {
   return (
     <footer className="bg-black py-8 text-center text-gray-400">
-      <p>&copy; 2025 My Company. All rights reserved.</p>
+      <p>&copy; 2025 Graham Elwood. All rights reserved.</p>
       <div className="mt-4 space-x-4">
-        <a href="https://twitter.com" aria-label="Twitter">Twitter</a>
-        <a href="https://github.com" aria-label="GitHub">GitHub</a>
+        <a href="https://x.com/grahamelwood" aria-label="Twitter">Twitter</a>
       </div>
     </footer>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -6,8 +6,7 @@ export default function Navbar() {
       <div className="max-w-6xl mx-auto flex items-center justify-between p-4">
         <a href="/" className="text-xl font-bold">Logo</a>
         <div className="space-x-4">
-          <a href="/features" className="hover:underline">Features</a>
-          <a href="/signup" className="hover:underline">Sign Up</a>
+          <a href="#features" className="hover:underline">Features</a>
         </div>
       </div>
     </nav>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -3,5 +3,6 @@
 @tailwind utilities;
 
 body {
-  @apply bg-black text-white antialiased;
+  @apply bg-black text-white antialiased font-medium;
+  font-family: 'Poppins', sans-serif;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,14 @@
+import defaultTheme from 'tailwindcss/defaultTheme';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Poppins', ...defaultTheme.fontFamily.sans],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- Use Poppins as default font with medium weight for a modern feel
- Anchor navbar features link and remove sign-up
- Update footer with Graham Elwood branding and Twitter link

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c5109c7e90832fb4fed3860cb17647